### PR TITLE
reverse token and endpoint priority - fixes #16

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,18 +6,21 @@ function ghGot(path, opts) {
 		return Promise.reject(new TypeError(`Expected 'path' to be a string, got ${typeof path}`));
 	}
 
-	opts = Object.assign({json: true, endpoint: 'https://api.github.com/'}, opts);
+	const env = process.env;
+
+	opts = Object.assign({
+		json: true,
+		token: env.GITHUB_TOKEN,
+		endpoint: env.GITHUB_ENDPOINT ? env.GITHUB_ENDPOINT.replace(/[^/]$/, '$&/') : 'https://api.github.com/'
+	}, opts);
 
 	opts.headers = Object.assign({
 		'accept': 'application/vnd.github.v3+json',
 		'user-agent': 'https://github.com/sindresorhus/gh-got'
 	}, opts.headers);
 
-	const env = process.env;
-	const token = env.GITHUB_TOKEN || opts.token;
-
-	if (token) {
-		opts.headers.authorization = `token ${token}`;
+	if (opts.token) {
+		opts.headers.authorization = `token ${opts.token}`;
 	}
 
 	// https://developer.github.com/v3/#http-verbs
@@ -25,8 +28,7 @@ function ghGot(path, opts) {
 		opts.headers['content-length'] = 0;
 	}
 
-	const endpoint = env.GITHUB_ENDPOINT ? env.GITHUB_ENDPOINT.replace(/[^/]$/, '$&/') : opts.endpoint;
-	const url = /https?/.test(path) ? path : endpoint + path;
+	const url = /https?/.test(path) ? path : opts.endpoint + path;
 
 	if (opts.stream) {
 		return got.stream(url, opts);

--- a/readme.md
+++ b/readme.md
@@ -63,7 +63,7 @@ Type: `string`
 
 GitHub [access token](https://github.com/settings/tokens/new).
 
-Can be overridden globally with the `GITHUB_TOKEN` environment variable.
+Can be set globally with the `GITHUB_TOKEN` environment variable.
 
 ### endpoint
 
@@ -72,7 +72,7 @@ Default: `https://api.github.com/`
 
 To support [GitHub Enterprise](https://enterprise.github.com).
 
-Can be overridden globally with the `GITHUB_ENDPOINT` environment variable.
+Can be set globally with the `GITHUB_ENDPOINT` environment variable.
 
 
 ## License

--- a/test.js
+++ b/test.js
@@ -16,14 +16,26 @@ test('accepts options', async t => {
 	t.is((await m('users/sindresorhus', {})).body.login, 'sindresorhus');
 });
 
-test.serial('token option', async t => {
+test.serial('global token option', async t => {
 	process.env.GITHUB_TOKEN = 'fail';
 	await t.throws(m('users/sindresorhus'), 'Response code 401 (Unauthorized)');
 	process.env.GITHUB_TOKEN = token;
 });
 
-test('endpoint option', async t => {
+test('token option', t => {
+	t.throws(m('users/sindresorhus', {token: 'fail'}), 'Response code 401 (Unauthorized)');
+});
+
+test.serial('global endpoint option', async t => {
+	process.env.GITHUB_ENDPOINT = 'fail';
+	await t.throws(m('users/sindresorhus', {retries: 1}), /ENOTFOUND/);
+	delete process.env.GITHUB_ENDPOINT;
+});
+
+test.serial('endpoint option', async t => {
+	process.env.GITHUB_ENDPOINT = 'https://api.github.com/';
 	await t.throws(m('users/sindresorhus', {endpoint: 'fail', retries: 1}), /ENOTFOUND/);
+	delete process.env.GITHUB_ENDPOINT;
 });
 
 test('stream interface', async t => {


### PR DESCRIPTION
`options.token` is higher priority as discussed in #16.

--------

`options.endpoint` also has a higher priority then `process.env.GITHUB_ENDPOINT`