### PR TITLE
fixed http(s) url check

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ function ghGot(path, opts) {
 		opts.headers['content-length'] = 0;
 	}
 
-	const url = /https?/.test(path) ? path : opts.endpoint + path;
+	const url = /^https?/.test(path) ? path : opts.endpoint + path;
 
 	if (opts.stream) {
 		return got.stream(url, opts);


### PR DESCRIPTION
example repo: https://github.com/mjackson/http-client.git

`ghGot('repos/mjackson/http-client')  ` will be regarded as a http url