### PR TITLE
Stringify body as JSON by default

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 'use strict';
 const got = require('got');
+const isPlainObj = require('is-plain-obj');
 
 function ghGot(path, opts) {
 	if (typeof path !== 'string') {
@@ -26,6 +27,11 @@ function ghGot(path, opts) {
 	// https://developer.github.com/v3/#http-verbs
 	if (opts.method && opts.method.toLowerCase() === 'put' && !opts.body) {
 		opts.headers['content-length'] = 0;
+	}
+
+	if (isPlainObj(opts.body)) {
+		opts.headers['content-type'] = 'application/json';
+		opts.body = JSON.stringify(opts.body);
 	}
 
 	const url = /^https?/.test(path) ? path : opts.endpoint + path;

--- a/package.json
+++ b/package.json
@@ -33,11 +33,13 @@
     "utility"
   ],
   "dependencies": {
-    "got": "^6.2.0"
+    "got": "^6.2.0",
+    "is-plain-obj": "^1.1.0"
   },
   "devDependencies": {
     "ava": "*",
     "get-stream": "^2.0.0",
+    "nock": "^8.0.0",
     "xo": "*"
   },
   "xo": {

--- a/readme.md
+++ b/readme.md
@@ -74,6 +74,12 @@ To support [GitHub Enterprise](https://enterprise.github.com).
 
 Can be set globally with the `GITHUB_ENDPOINT` environment variable.
 
+### body
+
+Type: `object`
+
+The body can be specified as a plain object and will be serialized as JSON with the appropriate headers set.
+
 
 ## License
 

--- a/test.js
+++ b/test.js
@@ -1,4 +1,5 @@
 import test from 'ava';
+import nock from 'nock';
 import getStream from 'get-stream';
 import m from './';
 
@@ -44,4 +45,15 @@ test.serial('endpoint option', async t => {
 test('stream interface', async t => {
 	t.is(JSON.parse(await getStream(m.stream('users/sindresorhus'))).login, 'sindresorhus');
 	t.is(JSON.parse(await getStream(m.stream.get('users/sindresorhus'))).login, 'sindresorhus');
+});
+
+test('json body', async t => {
+	const endpoint = 'http://mock-endpoint';
+	const body = {test: [1, 3, 3, 7]};
+	const reply = {ok: true};
+
+	const scope = nock(endpoint).post('/test', body).reply(200, reply);
+
+	t.deepEqual((await m('/test', {endpoint, body})).body, reply);
+	t.truthy(scope.isDone());
 });


### PR DESCRIPTION
I wanted to add a test but I'm not sure exactly what direction to take since POST requests usually modify remote state. My current ideas are

- Edit a gist that we create specifically for this
- Post a reaction to a specific comment
- Start an HTTP server, set endpoint to `localhost:randomport` and verify that body is JSON
- Use [nock](https://npmjs.com/nock) or similar to capture the outgoing request

Actually, maybe we want to use Nock in all the tests since it won't require an active connection and token to Github, thoughts?

-

Fixes #20.