### PR TITLE
Use error message returned from GitHub

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ function ghGot(path, opts) {
 	}, opts);
 
 	opts.headers = Object.assign({
-		'accept': 'application/vnd.github.v3+json',
+		accept: 'application/vnd.github.v3+json',
 		'user-agent': 'https://github.com/sindresorhus/gh-got'
 	}, opts.headers);
 
@@ -42,7 +42,14 @@ function ghGot(path, opts) {
 		return got.stream(url, opts);
 	}
 
-	return got(url, opts);
+	return got(url, opts).catch(err => {
+		if (err.response && isPlainObj(err.response.body)) {
+			err.name = 'GithubError';
+			err.message = `${err.response.body.message} (${err.statusCode})`;
+		}
+
+		throw err;
+	});
 }
 
 const helpers = [

--- a/readme.md
+++ b/readme.md
@@ -55,7 +55,9 @@ ghGot('https://api.github.com/users/sindresorhus', {token: 'foo'}).then(res => {
 
 ## API
 
-Same as [`got`](https://github.com/sindresorhus/got) (including the stream API and aliases), but with some additional options:
+Same as [`got`](https://github.com/sindresorhus/got) (including the stream API and aliases), but with some additional options below.
+
+Errors are improved by using the custom GitHub error messages. Doesn't apply to the stream API.
 
 ### token
 

--- a/test.js
+++ b/test.js
@@ -23,8 +23,8 @@ test.serial('global token option', async t => {
 	process.env.GITHUB_TOKEN = token;
 });
 
-test('token option', t => {
-	t.throws(m('users/sindresorhus', {token: 'fail'}), 'Bad credentials (401)');
+test('token option', async t => {
+	await t.throws(m('users/sindresorhus', {token: 'fail'}), 'Bad credentials (401)');
 });
 
 test.serial('global endpoint option', async t => {

--- a/test.js
+++ b/test.js
@@ -19,12 +19,12 @@ test('accepts options', async t => {
 
 test.serial('global token option', async t => {
 	process.env.GITHUB_TOKEN = 'fail';
-	await t.throws(m('users/sindresorhus'), 'Response code 401 (Unauthorized)');
+	await t.throws(m('users/sindresorhus'), 'Bad credentials (401)');
 	process.env.GITHUB_TOKEN = token;
 });
 
 test('token option', t => {
-	t.throws(m('users/sindresorhus', {token: 'fail'}), 'Response code 401 (Unauthorized)');
+	t.throws(m('users/sindresorhus', {token: 'fail'}), 'Bad credentials (401)');
 });
 
 test.serial('global endpoint option', async t => {
@@ -56,4 +56,10 @@ test('json body', async t => {
 
 	t.deepEqual((await m('/test', {endpoint, body})).body, reply);
 	t.truthy(scope.isDone());
+});
+
+test('custom error', async t => {
+	const err = await t.throws(m('users/sindresorhus', {token: 'fail'}));
+	t.is(err.name, 'GithubError');
+	t.is(err.message, 'Bad credentials (401)');
 });


### PR DESCRIPTION
As discussed in #19, I skipped formatting the errors in the streaming API. Not sure how you want it documented though so any input on that would be helpful.

Also, feels like the tests fails because of some globals leaking out from the serial tests. Have something changed in `ava` regarding the order in which the tests are ran.

---

Fixes #19 