### PR TITLE
Support `options.endpoint` without trailing slash

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ function ghGot(path, opts) {
 		return Promise.reject(new TypeError(`Expected \`path\` to be a string, got ${typeof path}`));
 	}
 
-	const {env} = process;
+	const env = process.env;
 
 	opts = Object.assign({
 		json: true,

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ function ghGot(path, opts) {
 	opts = Object.assign({
 		json: true,
 		token: env.GITHUB_TOKEN,
-		endpoint: env.GITHUB_ENDPOINT ? env.GITHUB_ENDPOINT.replace(/[^/]$/, '$&/') : 'https://api.github.com/'
+		endpoint: env.GITHUB_ENDPOINT ? env.GITHUB_ENDPOINT : 'https://api.github.com/'
 	}, opts);
 
 	opts.headers = Object.assign({
@@ -29,7 +29,7 @@ function ghGot(path, opts) {
 		opts.headers['content-length'] = 0;
 	}
 
-	const url = /^https?/.test(path) ? path : opts.endpoint + path;
+	const url = /^https?/.test(path) ? path : opts.endpoint.replace(/\/$/, '') + '/' + path.replace(/^\//, '');
 
 	if (opts.stream) {
 		return got.stream(url, opts);

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ function ghGot(path, opts) {
 		return Promise.reject(new TypeError(`Expected \`path\` to be a string, got ${typeof path}`));
 	}
 
-	const env = process.env;
+	const {env} = process;
 
 	opts = Object.assign({
 		json: true,

--- a/test.js
+++ b/test.js
@@ -17,6 +17,14 @@ test('accepts options', async t => {
 	t.is((await m('users/sindresorhus', {})).body.login, 'sindresorhus');
 });
 
+test('accepts options.endpoint without trailing slash', async t => {
+	t.is((await m('users/sindresorhus', {endpoint: 'https://api.github.com'})).body.login, 'sindresorhus');
+});
+
+test('dedupes slashes', async t => {
+	t.is((await m('/users/sindresorhus', {endpoint: 'https://api.github.com/'})).body.login, 'sindresorhus');
+});
+
 test.serial('global token option', async t => {
 	process.env.GITHUB_TOKEN = 'fail';
 	await t.throws(m('users/sindresorhus'), 'Bad credentials (401)');


### PR DESCRIPTION
Any endpoint passed via options without trailing slash was failing, because trailing slash was only massaged when passed via env. Refactored to use url.resolve instead of manual replace.

Also, running `npm test` on `master` was broken until I added one object destructuring.