### PR TITLE
Remove duplicated code

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,10 +17,6 @@ const create = () => got.create({
 			options.headers.authorization = `token ${options.token}`;
 		}
 
-		if (options.method && options.method === 'PUT' && !options.body) {
-			options.headers['content-length'] = 0;
-		}
-
 		if (options.stream) {
 			return next(options);
 		}

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 		"utility"
 	],
 	"dependencies": {
-		"got": "^9.1.0"
+		"got": "^9.2.0"
 	},
 	"devDependencies": {
 		"ava": "^1.0.0-beta.7",


### PR DESCRIPTION
Because `got` has it implemented already.