### PR TITLE
Don't override `authorization` header if it already exists

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ const create = () => got.create({
 	methods: got.defaults.methods,
 	handler: (options, next) => {
 		if (options.token) {
-			options.headers.authorization = `token ${options.token}`;
+			options.headers.authorization = options.headers.authorization || `token ${options.token}`;
 		}
 
 		if (options.method && options.method === 'PUT' && !options.body) {

--- a/readme.md
+++ b/readme.md
@@ -88,6 +88,31 @@ Type: `Object`
 
 Can be specified as a plain object and will be serialized as JSON with the appropriate headers set.
 
+## Authorization
+
+Authorization for GitHub uses the following logic:
+
+1. If `options.headers.authorization` is passed to `gh-got`, then this will be used as first preference
+2. If `options.token` is set then the `Authorization` header will be set to `token <options.token>`
+3. If `options.headers.authorization` and `options.token` are not set, then the `Authorization` header will be set to `token <process.env.GITHUB_TOKEN>`
+
+In most cases this means you can simply set `GITHUB_TOKEN`, but it also allows it to be overridden by setting `options.token` or `options.headers.authorization` explicitly. For example, if [authenticating as a GitHub App](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app), you could do the following:
+
+```js
+const ghGot = require(`gh-got`);
+
+(async () => {
+	const options = {
+		headers: {
+			authorization: `Bearer ${jwt}`
+		}
+	};
+	const {body} = await ghGot('app', options);
+
+	console.log(body.name);
+	//=> 'MyApp'
+})();
+```
 
 ## License
 

--- a/readme.md
+++ b/readme.md
@@ -93,8 +93,8 @@ Can be specified as a plain object and will be serialized as JSON with the appro
 Authorization for GitHub uses the following logic:
 
 1. If `options.headers.authorization` is passed to `gh-got`, then this will be used as first preference
-2. If `options.token` is set then the `Authorization` header will be set to `token <options.token>`
-3. If `options.headers.authorization` and `options.token` are not set, then the `Authorization` header will be set to `token <process.env.GITHUB_TOKEN>`
+2. If `options.token` is provided then the `Authorization` header will be set to `token <options.token>`
+3. If `options.headers.authorization` and `options.token` are not provided, then the `Authorization` header will be set to `token <process.env.GITHUB_TOKEN>`
 
 In most cases this means you can simply set `GITHUB_TOKEN`, but it also allows it to be overridden by setting `options.token` or `options.headers.authorization` explicitly. For example, if [authenticating as a GitHub App](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app), you could do the following:
 

--- a/readme.md
+++ b/readme.md
@@ -88,15 +88,16 @@ Type: `Object`
 
 Can be specified as a plain object and will be serialized as JSON with the appropriate headers set.
 
+
 ## Authorization
 
 Authorization for GitHub uses the following logic:
 
-1. If `options.headers.authorization` is passed to `gh-got`, then this will be used as first preference
-2. If `options.token` is provided then the `Authorization` header will be set to `token <options.token>`
-3. If `options.headers.authorization` and `options.token` are not provided, then the `Authorization` header will be set to `token <process.env.GITHUB_TOKEN>`
+1. If `options.headers.authorization` is passed to `gh-got`, then this will be used as first preference.
+2. If `options.token` is provided, then the `authorization` header will be set to `token <options.token>`.
+3. If `options.headers.authorization` and `options.token` are not provided, then the `authorization` header will be set to `token <process.env.GITHUB_TOKEN>`
 
-In most cases this means you can simply set `GITHUB_TOKEN`, but it also allows it to be overridden by setting `options.token` or `options.headers.authorization` explicitly. For example, if [authenticating as a GitHub App](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app), you could do the following:
+In most cases, this means you can simply set `GITHUB_TOKEN`, but it also allows it to be overridden by setting `options.token` or `options.headers.authorization` explicitly. For example, if [authenticating as a GitHub App](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app), you could do the following:
 
 ```js
 const ghGot = require(`gh-got`);
@@ -113,6 +114,7 @@ const ghGot = require(`gh-got`);
 	//=> 'MyApp'
 })();
 ```
+
 
 ## License
 


### PR DESCRIPTION
Only use `options.token` to set `options.headers.authorization` if that header is current unset. 

This covers the case where:

1. User has a `GITHUB_TOKEN` defined in env
2. User/app has explicitly set an authorization header and is definitely not expecting it to get ignored/overwritten

This is particularly important also for GitHub "Apps" which need to [authentication themselves via `Bearer` not `token`](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app), so it's impossible to pass that in `options.token` either.